### PR TITLE
changed font-family for code

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -51,7 +51,7 @@ h4 {
 
 code,
 code span {
-    font-family: 'Vera', sans-serif !important;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace, sans-serif !important;
 }
 
 .hljs-comment {


### PR DESCRIPTION
github README.md 의 `` ``` `` 에 적용된 font-family 를 지정했습니다.
